### PR TITLE
Fix: 하단의 네비게이션 바 삭제, 상단에 아이콘 추가

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,3 +88,7 @@
     @apply bg-background text-foreground;
   }
 }
+/*
+html {
+  font-family: var(--font-sans);
+}*/

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,20 @@ export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
-}>) {
+}>) 
+
+  /*{
+  return (
+    <html
+      lang="en"
+      className={`${GeistSans.variable} ${GeistMono.variable}`}
+    >
+      <body>{children}</body>
+    </html>
+  )
+}*/
+
+  {
   return (
     <html lang="en">
       <head>

--- a/app/my-posts/page.tsx
+++ b/app/my-posts/page.tsx
@@ -95,9 +95,9 @@ export default function MyPostsPage() {
                   <div className="flex justify-between items-start mb-3">
                     <Badge
                       variant="secondary"
-                      className={`${post.sport === "축구" ? "bg-blue-100 text-blue-700" : "bg-green-100 text-green-700"}`}
+                      className={`${post.sports === "축구" ? "bg-blue-100 text-blue-700" : "bg-green-100 text-green-700"}`}
                     >
-                      {post.sport}
+                      {post.sports}
                     </Badge>
                     <div className="flex items-center gap-2">
                       <Link href={`/edit-post/${post.id}`}>
@@ -132,7 +132,7 @@ export default function MyPostsPage() {
                     <div className="flex items-center gap-2">
                       <Users className="w-4 h-4 text-green-500" />
                       <span>
-                        {post.currentParticipants}/{post.maxParticipants}명
+                        {post.currentPeople}/{post.maxPeople}명
                       </span>
                     </div>
                   </div>
@@ -173,7 +173,7 @@ export default function MyPostsPage() {
         )}
       </div>
 
-      {/* Bottom Navigation */}
+      {/* Bottom Navigation 
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2">
         <div className="flex justify-around">
           <Link href="/" className="flex flex-col items-center gap-1 text-gray-400">
@@ -195,7 +195,7 @@ export default function MyPostsPage() {
             <span className="text-xs">마이페이지</span>
           </Link>
         </div>
-      </div>
+      </div>*/}
     </div>
   )
 }

--- a/app/mypage/applications/page.tsx
+++ b/app/mypage/applications/page.tsx
@@ -304,7 +304,8 @@ export default function ApplicationsPage() {
           </>
         )}
       </div>
-
+      
+      {/*
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2">
         <div className="flex justify-around">
           <Link href="/" className="flex flex-col items-center gap-1 text-gray-400">
@@ -326,7 +327,7 @@ export default function ApplicationsPage() {
             <span className="text-xs">마이페이지</span>
           </Link>
         </div>
-      </div>
+      </div>*/}
     </div>
   )
 }

--- a/app/mypage/favorites/page.tsx
+++ b/app/mypage/favorites/page.tsx
@@ -335,7 +335,7 @@ export default function FavoritesPage() {
         )}
       </div>
 
-      {/* Bottom Navigation */}
+      {/* Bottom Navigation 
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2">
         <div className="flex justify-around">
           <Link href="/" className="flex flex-col items-center gap-1 text-gray-400">
@@ -357,7 +357,7 @@ export default function FavoritesPage() {
             <span className="text-xs">마이페이지</span>
           </Link>
         </div>
-      </div>
+      </div>*/}
     </div>
   )
 }

--- a/app/mypage/my-posts/page.tsx
+++ b/app/mypage/my-posts/page.tsx
@@ -535,7 +535,8 @@ function MyPostsContentComponent() {
           </div>
         )}
       </div>
-
+      
+      {/* 
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2">
         <div className="flex justify-around">
           <Link href="/" className="flex flex-col items-center gap-1 text-gray-400">
@@ -557,7 +558,7 @@ function MyPostsContentComponent() {
             <span className="text-xs">마이페이지</span>
           </Link>
         </div>
-      </div>
+      </div>*/}
     </div>
   )
 }

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -263,7 +263,24 @@ export default function MyPage() {
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
       <div className="bg-gradient-to-r from-blue-500 to-cyan-400 text-white p-6">
-        <div className="text-center">
+        <div className="text-center relative">
+          {/* 오른쪽 상단에 홈 아이콘 배치 */}
+          <Link href="/" className="absolute top-0 right-0 m-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-6 h-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="white"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3 10.75L12 4l9 6.75M4.5 10.75V19a1.25 1.25 0 001.25 1.25h3.5A1.25 1.25 0 0010.5 19v-4.25h3V19A1.25 1.25 0 0014.75 20.25h3.5A1.25 1.25 0 0019.5 19v-8.25"
+              />
+            </svg>
+          </Link>
           <div className="w-20 h-20 bg-white rounded-full mx-auto mb-4 flex items-center justify-center">
             <User className="w-10 h-10 text-blue-500" />
           </div>
@@ -366,7 +383,7 @@ export default function MyPage() {
         </div>
       </div>
 
-      {/* Bottom Navigation */}
+      {/* Bottom Navigation 
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2">
         <div className="flex justify-around">
           <Link href="/" className="flex flex-col items-center gap-1 text-gray-400">
@@ -388,7 +405,7 @@ export default function MyPage() {
             <span className="text-xs">마이페이지</span>
           </Link>
         </div>
-      </div>
+      </div>*/}
     </div>
   )
 }

--- a/app/mypage/profile-edit/page.tsx
+++ b/app/mypage/profile-edit/page.tsx
@@ -373,7 +373,8 @@ export default function ProfileEditPage() {
           </Button>
         </div>
       </div>
-
+      
+      {/* 
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2">
         <div className="flex justify-around">
           <Link href="/" className="flex flex-col items-center gap-1 text-gray-400">
@@ -395,7 +396,7 @@ export default function ProfileEditPage() {
             <span className="text-xs">마이페이지</span>
           </Link>
         </div>
-      </div>
+      </div>*/}
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -340,8 +340,25 @@ export default function MainPage() {
             <h1 className="text-xl font-bold">스포츠 메이트</h1>
           </div>
           <div className="flex items-center gap-2">
-            <Bell className="w-6 h-6" />
-            <Link href="/login">
+            {/*<Bell className="w-6 h-6" />*/}
+            {/* 메인페이지(홈) 아이콘 */}
+            <Link href="/">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-6 h-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="white"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 10.75L12 4l9 6.75M4.5 10.75V19a1.25 1.25 0 001.25 1.25h3.5A1.25 1.25 0 0010.5 19v-4.25h3V19A1.25 1.25 0 0014.75 20.25h3.5A1.25 1.25 0 0019.5 19v-8.25"
+                />
+              </svg>
+            </Link>
+            <Link href={nickname ? "/mypage" : "/login"}>
               <User className="w-6 h-6" />
             </Link>
           </div>
@@ -613,7 +630,7 @@ export default function MainPage() {
         )}
       </div>
 
-      {/* Bottom Navigation */}
+      {/* Bottom Navigation 
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2">
         <div className="flex justify-around">
           <Link href="/" className="flex flex-col items-center gap-1 text-blue-500">
@@ -635,7 +652,7 @@ export default function MainPage() {
             <span className="text-xs">마이페이지</span>
           </Link>
         </div>
-      </div>
+      </div>*/}
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,6 +155,13 @@ export default function MainPage() {
     }
   }
 
+  useEffect(() => {
+      console.log(posts); // 받아온 데이터 형태 콘솔에서 확인 가능
+      if (posts.length > 0) {
+        console.log(posts[0].date); // 첫 번째 포스트의 date 필드
+      }
+  }, [posts]);
+  
   const fetchFavorites = async () => {
     try {
       const ids = await apiClient.getMyFollows()
@@ -347,7 +354,7 @@ export default function MainPage() {
           </p>
         </div>
 
-        {/* Search Bar */}
+        {/* Search Bar 
         <div className="relative">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
           <Input
@@ -356,7 +363,7 @@ export default function MainPage() {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
-        </div>
+        </div>*/}
       </div>
 
       <div className="p-4 pb-20">
@@ -380,7 +387,19 @@ export default function MainPage() {
               {selectedGender}
               <ChevronDown className="w-3 h-3" />
             </Button>
-          
+            <div className="flex-1 flex">
+              <div className="ml-auto"></div>
+                <Link href="/create-post">
+                  <Button
+                    variant="default"
+                    size="sm"
+                    className="bg-blue-500 text-white whitespace-nowrap flex items-center gap-1 font-medium"
+                    style={{ minWidth: "88px" }}
+                  >
+                    +  새 모집글 
+                  </Button>
+                </Link>
+              </div> 
         </div>
 
         {/* View Mode Toggle */}
@@ -573,7 +592,11 @@ export default function MainPage() {
                           </div>
                         </div>
                         <div className="text-right">
-                        {/*  <p className="text-lg font-bold text-red-500">{post.cost}원</p> */}
+                          <p className="text-lg font-bold text-red-500">
+                            {post.cost === 0 || post.cost === undefined
+                              ? "무료"
+                              : `${Number(post.cost).toLocaleString()}원`}
+                          </p>
                           <Link href={`/post/${post.id}`}>
                             <Button size="sm" className="bg-cyan-500 hover:bg-cyan-600 text-white">
                               상세보기

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -641,9 +641,9 @@ export default function EventDetail({}: EventDetailProps) {
     </div>
               
 
-      {/* Bottom Navigation  */}
+      {/* Bottom Navigation  
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-2">
-        <div className="flex justify-around">
+        <div className="">
           <Link href="/" className="flex flex-col items-center gap-1 text-gray-400">
             <div className="w-6 h-6 bg-gray-400 rounded-full flex items-center justify-center">
               <span className="text-white text-xs">🏠</span>
@@ -663,7 +663,7 @@ export default function EventDetail({}: EventDetailProps) {
             <span className="text-xs">마이페이지</span>
           </Link>
         </div>
-      </div>
+      </div>*/}
 
       {/* Floating Action Buttons */}
       <div className="fixed bottom-16 right-4 flex flex-col gap-2">


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/icon_navigation

### 🔑 주요 변경사항
- 하단에 있던 네비게이션 바 삭제
- 상단에 있던 알림 아이콘 삭제, 메인 페이지 아이콘 추가
- 로그인 시 상단의 사람 아이콘 누르면 마이 페이지로 이동, 비로그인 시 누르면 로그인 페이지로 이동

### 관련 이슈
- #32 
