### PR TITLE
Fix: 오늘날짜의 이전 시간이 나오는 문제 해결

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -254,16 +254,17 @@ export default function MainPage() {
     if (!regionMatch) return false;
 
     // 2. 날짜 필터 + 현재 시각 이후 모집글만
+    // 현재 시각 이후 모집글만 (항상 적용)
+    if (post.date) {
+      const postDateTime = new Date(post.date.replace(" ", "T"));
+      // 현재 시각 이후만 남김
+      if (postDateTime <= now) return false;
+    }
+
+    // 특정 날짜가 선택된 경우 해당 날짜만 필터링
     if (selectedDate) {
       const postDateStr = post.date?.split("T")[0];
       if (postDateStr !== selectedDate) return false;
-
-      // "YYYY-MM-DDTHH:mm:ss" 또는 "YYYY-MM-DD HH:mm:ss"
-      if (post.date) {
-        const postDateTime = new Date(post.date.replace(" ", "T"));
-        // 현재 시각 이후만 남김
-        if (postDateTime <= now) return false;
-      }
     }
     // selectedDate가 없으면 모두 통과
     return true;


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- 작업 중인 브랜치를 알려주세요.

### 🔑 주요 변경사항
- 모집글 리스트 조회 시, 같은 날짜의 지난 시간의 모집글이 보이지 않도록 수정
  - 시간 필터링 항상 적용: selectedDate가 있든 없든 현재 시각 이후의 모집글만 표시

### 관련 이슈
- #18 